### PR TITLE
fix(landscape): update multichain smart filter item to use multichain logo

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -385,7 +385,7 @@ landscape:
           - item:
             name: Smart Filter
             homepage_url: https://twitter.com/CoinSciences
-            logo: dlt-logo.svg
+            logo: multichain-logo-vector-2.svg
             crunchbase: https://www.crunchbase.com/organization/multichain
             repo_url: https://github.com/MultiChain/smart-filter-examples
             project: company


### PR DESCRIPTION
Update the Multichain smart filter item to use the converted logo
